### PR TITLE
Enqueue child-theme.min.css into the editor

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -11,9 +11,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 
-/** 
+/**
  * Enqueue child scripts and styles.
- */ 
+ */
 function uds_wordpress_child_scripts() {
 	// Get the theme data.
 	$the_theme     = wp_get_theme();
@@ -26,3 +26,16 @@ function uds_wordpress_child_scripts() {
 	wp_enqueue_style( 'uds-wordpress-child-styles', get_stylesheet_directory_uri() . '/js/child-theme.js', array( 'jquery' ), $js_child_version );
 }
 add_action( 'wp_enqueue_scripts', 'uds_wordpress_child_scripts' );
+
+//enqueue the child-theme.css into the editor
+if ( ! function_exists( 'uds_wp_gutenberg_child_css' ) ) {
+	/**
+	 * Load CSS styles in editor area.
+	 */
+	function uds_wp_gutenberg_child_css() {
+		add_theme_support( 'editor-styles' );
+		add_editor_style( 'css/child-theme.min.css' );
+
+	}
+}// End of if function_exists( 'uds_wp_gutenberg_child_css' ).
+add_action( 'after_setup_theme', 'uds_wp_gutenberg_child_css' );


### PR DESCRIPTION
I enqueued the child-theme css file into the editor side. 
Added the function to function.php:
```
	function uds_wp_gutenberg_child_css() {
		add_theme_support( 'editor-styles' );
		add_editor_style( 'css/child-theme.min.css' );

	} 
```
