### PR TITLE
Browser-sync

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -11,9 +11,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 
-/** 
+/**
  * Enqueue child scripts and styles.
- */ 
+ */
 function uds_wordpress_child_scripts() {
 	// Get the theme data.
 	$the_theme     = wp_get_theme();
@@ -26,3 +26,16 @@ function uds_wordpress_child_scripts() {
 	wp_enqueue_style( 'uds-wordpress-child-styles', get_stylesheet_directory_uri() . '/js/child-theme.js', array( 'jquery' ), $js_child_version );
 }
 add_action( 'wp_enqueue_scripts', 'uds_wordpress_child_scripts' );
+
+//enqueue the child-theme.css into the editor
+if ( ! function_exists( 'uds_wp_gutenberg_child_css' ) ) {
+	/**
+	 * Load CSS styles in editor area.
+	 */
+	function uds_wp_gutenberg_child_css() {
+		add_theme_support( 'editor-styles' );
+		add_editor_style( 'css/child-theme.min.css' );
+
+	}
+}// End of if function_exists( 'uds_wp_gutenberg_child_css' ).
+add_action( 'after_setup_theme', 'uds_wp_gutenberg_child_css' );

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -102,7 +102,8 @@ gulp.task( 'minifycss', function() {
 		)
 		.pipe( rename( { suffix: '.min' } ) )
 		.pipe( sourcemaps.write( './' ) )
-		.pipe( gulp.dest( paths.css ) );
+		.pipe( gulp.dest( paths.css ) )
+    .pipe(browserSync.reload({ stream: true }));
 } );
 
 /**
@@ -198,7 +199,8 @@ gulp.task( 'scripts', function() {
 		.src( scripts, { allowEmpty: true } )
 		.pipe( babel() )
 		.pipe( concat( 'theme.js' ) )
-		.pipe( gulp.dest( paths.js ) );
+		.pipe( gulp.dest( paths.js ) )
+    .pipe(browserSync.reload({ stream: true }));
 } );
 
 // Deleting any file inside the /src folder


### PR DESCRIPTION
I updated the gulpfile.js added the line: `pipe(browserSync.reload({ stream: true }))`
This should allow us to used the browser-sync feature and see the updates once saved.
You can test this by running **gulp watch-bs**. 

I have updated the parent theme with same updates and were approved and merged to develop.