### PR TITLE
Adding ACF local JSON save points. Cleanup functions.php

### DIFF
--- a/acf-json/index.php
+++ b/acf-json/index.php
@@ -1,0 +1,3 @@
+<?php
+// Silence is golden.
+?>

--- a/functions.php
+++ b/functions.php
@@ -10,7 +10,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-
 /**
  * Enqueue child scripts and styles.
  */
@@ -27,15 +26,18 @@ function uds_wordpress_child_scripts() {
 }
 add_action( 'wp_enqueue_scripts', 'uds_wordpress_child_scripts' );
 
-//enqueue the child-theme.css into the editor
-if ( ! function_exists( 'uds_wp_gutenberg_child_css' ) ) {
-	/**
-	 * Load CSS styles in editor area.
-	 */
-	function uds_wp_gutenberg_child_css() {
-		add_theme_support( 'editor-styles' );
-		add_editor_style( 'css/child-theme.min.css' );
-
-	}
-}// End of if function_exists( 'uds_wp_gutenberg_child_css' ).
+/**
+ * Enqueue the child-theme.css into the editor.
+ */
+function uds_wp_gutenberg_child_css() {
+	add_theme_support( 'editor-styles' );
+	add_editor_style( 'css/child-theme.min.css' );
+}
 add_action( 'after_setup_theme', 'uds_wp_gutenberg_child_css' );
+
+
+/**
+ * Other included partials for functions.php.
+ */
+require get_stylesheet_directory() . '/inc/custom-post-types.php';
+require get_stylesheet_directory() . '/inc/acf-register.php';

--- a/inc/acf-register.php
+++ b/inc/acf-register.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Additional functions for Advanced Custom Fields.
+ * 
+ * Contents:
+ *   - Load path for ACF groups from the parent.
+ *   - Register custom blocks for the theme.
+ *
+ * @package uds-wordpress-child-theme
+ */
+
+/**
+ * Add additional loading point for the parent theme's ACF groups.
+ *
+ * @return $paths
+ */
+function uds_wordpress_parent_theme_field_groups( $paths ) {
+	$path = get_template_directory() . '/acf-json';
+	$paths[] = $path;
+	return $paths;
+}
+add_filter( 'acf/settings/load_json', 'uds_wordpress_parent_theme_field_groups' );
+
+/**
+ * Create save point for the child theme's ACF groups.
+ *
+ * @return $path
+ */
+function uds_wordpress_child_theme_field_groups( $path ) {
+	$path = get_stylesheet_directory() . '/acf-json';
+	return $path;
+}
+add_filter( 'acf/settings/save_json', 'uds_wordpress_child_theme_field_groups' );
+
+/**
+ * Register additional custom blocks for the theme.
+ */
+function uds_wordpress_child_theme_acf_init_block_types() {
+	// The sky is the limit.
+}
+add_action( 'acf/init', 'uds_wordpress_child_theme_acf_init_block_types' );

--- a/inc/custom-post-types.php
+++ b/inc/custom-post-types.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Declare custom post types for the theme. 
+ * Yes, this is "supposed" to be in a plugin. ¯\_(ツ)_/¯
+ *
+ * @package uds-wordpress-child-theme
+ */
+
+/**
+ * CPT: Roll your definitions here.
+ */

--- a/style.css
+++ b/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: UDS WordPress Child Template
-Theme URI: https://github.com/asuengineering/asu-twentytwenty-child
+Theme URI: [Insert your URL here]
 Author: ASU Engineering
 Author URI: https://github.com/asuengineering
 Description: Child theme template for UDS WordPress
@@ -8,7 +8,7 @@ Version: 0.1.0
 
 Template: UDS-WordPress-Theme
 
-GitHub Theme URI: https://github.com/asu-ke-web-services/UDS-WordPress-Child-Theme
+GitHub Theme URI: [Insert your URL here if you want to support GitHub Updater]
 
 License: GNU GPL version 2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Did a couple of things here.

- Unwrapped the conditional statement surrounding the admin enqueue statement in `functions.php`. No need for it since we're already in a child theme.
- Created an empty `/acf-json` folder for syncing purposes.
- Added a pair of sample `functions.php` partials that can optionally be included depending on what your goal with the child theme will be. 
  - `acf-register.php` sets the local JSON load point back to the parent theme, adds a child theme save point for additional field groups and provides a place to start registering additional blocks.
  - `custom-post-types.php` Adds a blank file from which to insert your CPT/taxonomy definitions. Included first in case the blocks that you may want to build with ACF need to act on the defined CPT.